### PR TITLE
updated configuration names

### DIFF
--- a/src/main/java/org/embulk/output/ElasticsearchOutputPlugin.java
+++ b/src/main/java/org/embulk/output/ElasticsearchOutputPlugin.java
@@ -46,7 +46,7 @@ public class ElasticsearchOutputPlugin
     public interface NodeAddressTask
             extends Task
     {
-        @Config("hsot")
+        @Config("host")
         public String getHost();
 
         @Config("port")


### PR DESCRIPTION
- `transport_addresses` seems too long. "nodes" should be good enough.
- `doc_id` is not actually id but a column name.
- I think `index_name` should not have default value because it's always unexpected for users to use a new index.
