### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ```yaml
 out:
   type: elasticsearch
-  node:
+  nodes:
   - {host: localhost, port: 9300}
   index: <index name>
   index_type: <index type>


### PR DESCRIPTION
s/node:/nodes:/g

Could I ask to fix http://www.rubydoc.info/gems/embulk-output-elasticsearch/0.1.3 too.
And there is another typo s/index_name:/index:/g
