### PR TITLE
added clusetr_name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ## Configuration
 
 - **nodes**: list of nodes. nodes are pairs of host and port (list, required)
+- **cluster_name**: name of the cluster (string, default is "elasticsearch")
 - **index_name**: index name (string, required)
 - **index_type**: index type (string, required)
 - **doc_id_column**: document id column (string, default is null)


### PR DESCRIPTION
Java client library needs cluster name to load data to a cluster if name of the cluster is not "elasticsearch". See "Note" at: http://www.elastic.co/guide/en/elasticsearch/client/java-api/current/client.html#transport-client
