### PR TITLE
Job should fail when nodes are down while executing

### DIFF
--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPlugin.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPlugin.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.AliasOrIndex;
@@ -43,6 +44,7 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
+import org.embulk.config.UserDataException;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.Exec;
@@ -171,6 +173,8 @@ public class ElasticsearchOutputPlugin
                 reAssignAlias(task.getAlias().orNull(), task.getIndex(), client);
             } catch (IndexNotFoundException | InvalidAliasNameException e) {
                 throw new ConfigException(e);
+            } catch (NoNodeAvailableException e) {
+                throw new ConnectionException(e);
             }
         }
     }
@@ -186,8 +190,8 @@ public class ElasticsearchOutputPlugin
         for (NodeAddressTask node : nodes) {
             try {
                 client.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(node.getHost()), node.getPort()));
-            } catch (UnknownHostException e) {
-                Throwables.propagate(e);
+            } catch (UnknownHostException | NoNodeAvailableException e) {
+                throw new ConnectionException(e);
             }
         }
         return client;
@@ -226,7 +230,12 @@ public class ElasticsearchOutputPlugin
             @Override
             public void afterBulk(long executionId, BulkRequest request, Throwable failure)
             {
-                log.warn("Got the error during bulk processing", failure);
+                if (failure.getClass() == NoNodeAvailableException.class) {
+                    log.error("Got the error during bulk processing", failure);
+                    throw new ConnectionException(failure);
+                } else {
+                    log.warn("Got the error during bulk processing", failure);
+                }
             }
         }).setBulkActions(task.getBulkActions())
           .setBulkSize(new ByteSizeValue(task.getBulkSize()))
@@ -376,7 +385,7 @@ public class ElasticsearchOutputPlugin
                     contextBuilder.endObject();
                     bulkProcessor.add(newIndexRequest(getIdValue(idColumn)).source(contextBuilder));
 
-                } catch (IOException e) {
+                } catch (ConnectionException | IOException e) {
                     Throwables.propagate(e); //  TODO error handling
                 }
             }
@@ -543,4 +552,17 @@ public class ElasticsearchOutputPlugin
         Timestamp time = Exec.getTransactionTime();
         return indexName + new SimpleDateFormat("_yyyyMMdd-HHmmss").format(time.toEpochMilli());
     }
+
+    public class ConnectionException extends RuntimeException implements UserDataException
+    {
+        protected ConnectionException()
+        {
+        }
+        
+        public ConnectionException(Throwable cause)
+        {
+            super(cause);
+        }
+    }
+
 }

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
@@ -168,6 +168,22 @@ public class TestElasticsearchOutputPlugin
     }
 
     @Test
+    public void testTransaction()
+    {
+        ConfigSource config = config();
+        Schema schema = config.getNested("parser").loadConfig(CsvParserPlugin.PluginTask.class).getSchemaConfig().toSchema();
+        plugin.transaction(config, schema, 0, new OutputPlugin.Control()
+        {
+            @Override
+            public List<TaskReport> run(TaskSource taskSource)
+            {
+                return Lists.newArrayList(Exec.newTaskReport());
+            }
+        });
+        // no error happens
+    }
+
+    @Test
     public void testResume()
     {
         ConfigSource config = config();
@@ -184,31 +200,12 @@ public class TestElasticsearchOutputPlugin
     }
 
     @Test
-    public void testTransaction()
+    public void testCleanup()
     {
-        ConfigSource config = Exec.newConfigSource()
-            .set("in", inputConfig())
-            .set("parser", parserConfig(schemaConfig()))
-            .set("type", "elasticsearch")
-            .set("mode", "replace")
-            .set("nodes", ES_NODES)
-            .set("cluster_name", ES_CLUSTER_NAME)
-            .set("index", ES_INDEX)
-            .set("index_type", ES_INDEX_TYPE)
-            .set("id", ES_ID)
-            .set("bulk_actions", ES_BULK_ACTIONS)
-            .set("bulk_size", ES_BULK_SIZE)
-            .set("concurrent_requests", ES_CONCURRENT_REQUESTS
-            );
+        ConfigSource config = config();
         Schema schema = config.getNested("parser").loadConfig(CsvParserPlugin.PluginTask.class).getSchemaConfig().toSchema();
-        plugin.transaction(config, schema, 0, new OutputPlugin.Control()
-        {
-            @Override
-            public List<TaskReport> run(TaskSource taskSource)
-            {
-                return Lists.newArrayList(Exec.newTaskReport());
-            }
-        });
+        PluginTask task = config.loadConfig(PluginTask.class);
+        plugin.cleanup(task.dump(), schema, 0, Arrays.asList(Exec.newTaskReport()));
         // no error happens
     }
 


### PR DESCRIPTION
Even if nodes goes down while executing, job result will become success at v0.2.0.
In this case, I think plugin should catch NoNodeAvailableException and job should fail.

Additionally, I moved replace processing from cleanup() to transaction() to avoid to execute replace processing when transaction() fails.
