### PR TITLE
Update elasticsearch client to 2.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ task gem(type: JRubyExec, dependsOn: ["build", "gemspec", "classpath"]) {
     doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "pkg") }
 }
 
+task "package"(dependsOn: ["gemspec", "classpath"]) << {
+    println "> Build succeeded."
+    println "> You can run embulk with '-L ${file(".").absolutePath}' argument."
+}
+
 task gemspec << { file("build/gemspec").write($/
 Gem::Specification.new do |spec|
   spec.name          = "${project.name}"

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.5"
     provided  "org.embulk:embulk-core:0.8.5"
-    compile 'org.elasticsearch:elasticsearch:2.0.0'
+    compile 'org.elasticsearch:elasticsearch:2.3.3'
 
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.5:tests"


### PR DESCRIPTION
We are currently using elasticsearch 2.3.3 in production and the current client (2.0.0) causes EsRejectedExecutionException when bulk loading data. Updating the client to 2.3.3 resolves the issue.
