### PR TITLE
Support SSL and Basic authentication(Shield)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Elasticsearch output plugin for Embulk
 
 **Notice** This plugin doesn't support [Amazon(AWS) Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/).
+This plugin uses HTTP/REST Client and haven't be implemented AWS authentication.
 - *[Amazon Elasticsearch Service Limits](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html)*
 
 ## Overview
@@ -15,6 +16,10 @@
 - **mode**: "insert" or "replace". See below(string, optional, default is insert)
 - **nodes**: list of nodes. nodes are pairs of host and port (list, required)
   - NOTE: This plugin uses HTTP/REST Clients and uses TCP:9200 as a default. TCP:9300 is usually used for Transport Client.
+- **use_ssl** Use SSL encryption (boolean, default is false)
+- **auth_method** (string, default is 'none') 'none'/'basic'. See also [Authentication](#authentication).
+- **user** Username for basic authentication (string, default is null)
+- **password** Password for above user (string, default is null)
 - ~~**cluster_name**: name of the cluster (string, default is "elasticsearch")~~ Not used now. May use in the future
 - **index**: index name (string, required)
 - **index_type**: index type (string, required)
@@ -47,6 +52,18 @@ out:
   - {host: localhost, port: 9200}
   index: <alias name> # plugin generates index name like <index>_%Y%m%d-%H%M%S 
   index_type: <index type>
+```
+
+### Authentication
+
+This plugin supports Basic authentication and works with [Elastic Cloud](https://cloud.elastic.co/) and 'Security'(formally Sield).
+'Security' also supports LDAP and Active Directory. This plugin doesn't supports these auth methods.
+
+```
+use_ssl: true
+auth_method: basic
+user: <username>
+password: <password>
 ```
 
 ## Example

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
@@ -3,6 +3,7 @@ package org.embulk.output.elasticsearch;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import org.eclipse.jetty.client.HttpResponseException;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
@@ -368,7 +369,8 @@ public class ElasticsearchHttpClient
         }
     }
 
-    private String getAuthorizationHeader(PluginTask task)
+    @VisibleForTesting
+    protected String getAuthorizationHeader(PluginTask task)
     {
         String header = "";
         if (task.getAuthMethod() == AuthMethod.BASIC) {

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
@@ -8,6 +8,7 @@ import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import org.embulk.config.ConfigException;
 import org.embulk.config.UserDataException;
+import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.AuthMethod;
 import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.NodeAddressTask;
 import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.PluginTask;
 import org.embulk.spi.DataException;
@@ -17,6 +18,8 @@ import org.embulk.util.retryhelper.jetty92.Jetty92RetryHelper;
 import org.embulk.util.retryhelper.jetty92.Jetty92SingleRequester;
 import org.embulk.util.retryhelper.jetty92.StringJetty92ResponseEntityReader;
 import org.slf4j.Logger;
+
+import javax.xml.bind.DatatypeConverter;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -292,6 +295,7 @@ public class ElasticsearchHttpClient
     private JsonNode sendRequest(String path, final HttpMethod method, PluginTask task, Jetty92RetryHelper retryHelper, final String content)
     {
         final String uri = createRequestUri(task, path);
+        final String authorizationHeader = getAuthorizationHeader(task);
 
         try {
             String responseBody = retryHelper.requestWithRetry(
@@ -306,6 +310,10 @@ public class ElasticsearchHttpClient
                                     .method(method);
                             if (method == HttpMethod.POST) {
                                 request.content(new StringContentProvider(content), "application/json");
+                            }
+
+                            if (!authorizationHeader.isEmpty()) {
+                                request.header("Authorization", authorizationHeader);
                             }
                             request.send(responseListener);
                         }
@@ -335,8 +343,9 @@ public class ElasticsearchHttpClient
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
+        String protocol = task.getUseSsl() ? "https" : "http";
         String nodeAddress = getRandomNodeAddress(task);
-        return String.format("%s://%s%s", "http", nodeAddress, path);
+        return String.format("%s://%s%s", protocol, nodeAddress, path);
     }
 
     // Return node address (RoundRobin)
@@ -357,6 +366,16 @@ public class ElasticsearchHttpClient
         catch (IOException ex) {
             throw new DataException(ex);
         }
+    }
+
+    private String getAuthorizationHeader(PluginTask task)
+    {
+        String header = "";
+        if (task.getAuthMethod() == AuthMethod.BASIC) {
+            String authString = task.getUser().get() + ":" + task.getPassword().get();
+            header = "Basic " + DatatypeConverter.printBase64Binary(authString.getBytes());
+        }
+        return header;
     }
 
     public class ResourceNotFoundException extends RuntimeException implements UserDataException

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
@@ -164,10 +164,7 @@ public class TestElasticsearchHttpClient
                 .set("index", "idx")
                 .set("index_type", "idx_type")
                 .set("nodes", ES_NODES);
-        PluginTask task = config.loadConfig(PluginTask.class);
 
-        Method method = ElasticsearchHttpClient.class.getDeclaredMethod("getAuthorizationHeader", PluginTask.class);
-        method.setAccessible(true);
-        assertThat(method.invoke(client, task).toString(), is("Basic dXNlcm5hbWU6cGFzc3dvcmQ="));
+        assertThat(client.getAuthorizationHeader(config.loadConfig(PluginTask.class)), is("Basic dXNlcm5hbWU6cGFzc3dvcmQ="));
     }
 }

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
@@ -3,6 +3,7 @@ package org.embulk.output.elasticsearch;
 import org.eclipse.jetty.http.HttpMethod;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
+import org.embulk.config.ConfigSource;
 import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.PluginTask;
 import org.embulk.spi.Exec;
 import org.embulk.spi.time.Timestamp;
@@ -16,6 +17,7 @@ import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 
 import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_INDEX;
+import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_NODES;
 import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_TEST_ALIAS;
 import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_TEST_INDEX2;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -148,5 +150,24 @@ public class TestElasticsearchHttpClient
             PluginTask task = utils.config().loadConfig(PluginTask.class);
             assertThat(client.isAliasExisting("non-existing-alias", task, retryHelper), is(false));
         }
+    }
+
+    @Test
+    public void testGetAuthorizationHeader() throws Exception
+    {
+        ElasticsearchHttpClient client = new ElasticsearchHttpClient();
+
+        ConfigSource config = Exec.newConfigSource()
+                .set("auth_method", "basic")
+                .set("user", "username")
+                .set("password", "password")
+                .set("index", "idx")
+                .set("index_type", "idx_type")
+                .set("nodes", ES_NODES);
+        PluginTask task = config.loadConfig(PluginTask.class);
+
+        Method method = ElasticsearchHttpClient.class.getDeclaredMethod("getAuthorizationHeader", PluginTask.class);
+        method.setAccessible(true);
+        assertThat(method.invoke(client, task).toString(), is("Basic dXNlcm5hbWU6cGFzc3dvcmQ="));
     }
 }

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
@@ -8,6 +8,7 @@ import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
+import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.AuthMethod;
 import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.Mode;
 import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.PluginTask;
 import org.embulk.spi.Exec;
@@ -211,6 +212,13 @@ public class TestElasticsearchOutputPlugin
     {
         assertThat(Mode.values().length, is(2));
         assertThat(Mode.valueOf("INSERT"), is(Mode.INSERT));
+    }
+
+    @Test
+    public void testAuthMethod()
+    {
+        assertThat(AuthMethod.values().length, is(2));
+        assertThat(AuthMethod.valueOf("BASIC"), is(AuthMethod.BASIC));
     }
 
     @Test(expected = ConfigException.class)


### PR DESCRIPTION
Related to #32 

This PR enables to use SSL and Basic authentication.
This implementation works with Elastic Cloud. Also works with local Elasticsearch server that was installed X-Pack security feature(formally called as 'Shield').

'Security' also supports other auth method like LDAP or ActiveDirectory.
But this PR doesn't contains support for such methods.

#### Process to enable 'security'(or shield) at local Elasticsearch server
```
# Install plugin
$ ./bin/plugin install license
$ ./bin/plugin install shield
$ ./bin/elasticsearch # start Es server

# Add user
$ ./bin/shield/esusers useradd admin -r admin # create 'admin' user as admin role
$ ./bin/shield/esusers useradd elastic -r power_user # create 'elastic' user as power_user role(read/write role)
```

#### References
[Using Elasticsearch HTTP/REST Clients with Shield | Shield [2.4] | Elastic](https://www.elastic.co/guide/en/shield/current/_using_elasticsearch_http_rest_clients_with_shield.html)