### PR TITLE
Improve export logic

### DIFF
--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -250,13 +250,11 @@ public class ElasticsearchOutputPluginDelegate
             }
         }
 
-        if (totalInserted > 0) {
-            log.info("Insert completed. {} records", totalInserted);
-            try (Jetty92RetryHelper retryHelper = createRetryHelper(task)) {
-                // Re assign alias only when repale mode
-                if (task.getMode().equals(Mode.REPLACE)) {
-                    client.reassignAlias(task.getAlias().orNull(), task.getIndex(), task, retryHelper);
-                }
+        log.info("Insert completed. {} records", totalInserted);
+        try (Jetty92RetryHelper retryHelper = createRetryHelper(task)) {
+            // Re assign alias only when repale mode
+            if (task.getMode().equals(Mode.REPLACE)) {
+                client.reassignAlias(task.getAlias().orNull(), task.getIndex(), task, retryHelper);
             }
         }
 

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -243,10 +243,10 @@ public class ElasticsearchOutputPluginDelegate
                                       int taskIndex,
                                       List<TaskReport> taskReports)
     {
-        int totalInserted = 0;
+        long totalInserted = 0;
         for (TaskReport taskReport : taskReports) {
             if (taskReport.has("inserted")) {
-                totalInserted += taskReport.get(int.class, "inserted");
+                totalInserted += taskReport.get(Long.class, "inserted");
             }
         }
 

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -2,8 +2,6 @@ package org.embulk.output.elasticsearch;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
@@ -11,7 +9,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.embulk.base.restclient.RestClientOutputPluginDelegate;
 import org.embulk.base.restclient.RestClientOutputTaskBase;
 import org.embulk.base.restclient.jackson.JacksonServiceRequestMapper;
-import org.embulk.base.restclient.jackson.JacksonTaskReportRecordBuffer;
 import org.embulk.base.restclient.jackson.JacksonTopLevelValueLocator;
 import org.embulk.base.restclient.jackson.scope.JacksonAllInObjectScope;
 import org.embulk.base.restclient.record.RecordBuffer;
@@ -213,6 +210,7 @@ public class ElasticsearchOutputPluginDelegate
                     throw new ConfigException(String.format("Invalid alias name [%s], an index exists with the same name as the alias", task.getAlias().orNull()));
                 }
             }
+            log.info(String.format("Inserting data into index[%s]", task.getIndex()));
         }
 
         if (task.getAuthMethod() == AuthMethod.BASIC) {
@@ -235,7 +233,8 @@ public class ElasticsearchOutputPluginDelegate
     @Override  // Overridden from |RecordBufferBuildable|
     public RecordBuffer buildRecordBuffer(PluginTask task)
     {
-        return new JacksonTaskReportRecordBuffer("records");
+        Jetty92RetryHelper retryHelper = createRetryHelper(task);
+        return new ElasticsearchRecordBuffer("records", task, retryHelper);
     }
 
     @Override
@@ -244,18 +243,16 @@ public class ElasticsearchOutputPluginDelegate
                                       int taskIndex,
                                       List<TaskReport> taskReports)
     {
-        ArrayNode records = JsonNodeFactory.instance.arrayNode();
+        int totalInserted = 0;
         for (TaskReport taskReport : taskReports) {
-            if (taskReport.has("records")) {
-                records.addAll(JacksonTaskReportRecordBuffer.resumeFromTaskReport(taskReport, "records"));
+            if (taskReport.has("inserted")) {
+                totalInserted += taskReport.get(int.class, "inserted");
             }
         }
 
-        if (records.size() > 0) {
+        if (totalInserted > 0) {
+            log.info("Insert completed. {} records", totalInserted);
             try (Jetty92RetryHelper retryHelper = createRetryHelper(task)) {
-                log.info(String.format("Inserting data into index[%s]", task.getIndex()));
-                client.push(records, task, retryHelper);
-
                 // Re assign alias only when repale mode
                 if (task.getMode().equals(Mode.REPLACE)) {
                     client.reassignAlias(task.getAlias().orNull(), task.getIndex(), task, retryHelper);

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchRecordBuffer.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchRecordBuffer.java
@@ -1,0 +1,98 @@
+package org.embulk.output.elasticsearch;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.google.common.base.Throwables;
+import org.embulk.base.restclient.jackson.JacksonServiceRecord;
+import org.embulk.base.restclient.record.RecordBuffer;
+import org.embulk.base.restclient.record.ServiceRecord;
+import org.embulk.config.TaskReport;
+import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.PluginTask;
+import org.embulk.spi.Exec;
+import org.embulk.util.retryhelper.jetty92.Jetty92RetryHelper;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * ElasticsearchRecordBuffer is an implementation of {@code RecordBuffer} which includes JSON output directly to Elasticsearch server.
+ */
+public class ElasticsearchRecordBuffer
+        extends RecordBuffer
+{
+    private final String attributeName;
+    private final PluginTask task;
+    private final long bulkActions;
+    private final long bulkSize;
+    private final ElasticsearchHttpClient client;
+    private final Jetty92RetryHelper retryHelper;
+    private final ObjectMapper mapper;
+    private final Logger log;
+    private int totalCount;
+    private int requestCount;
+    private long requestBytes;
+    private ArrayNode records;
+
+    public ElasticsearchRecordBuffer(String attributeName, PluginTask task, Jetty92RetryHelper retryHelper)
+    {
+        this.attributeName = attributeName;
+        this.task = task;
+        this.bulkActions = task.getBulkActions();
+        this.bulkSize = task.getBulkSize();
+        this.client = new ElasticsearchHttpClient();
+        this.retryHelper = retryHelper;
+        this.mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false);
+        this.records = JsonNodeFactory.instance.arrayNode();
+        this.totalCount = 0;
+        this.requestCount = 0;
+        this.requestBytes = 0;
+        this.log = Exec.getLogger(getClass());
+    }
+
+    @Override
+    public void bufferRecord(ServiceRecord serviceRecord)
+    {
+        JacksonServiceRecord jacksonServiceRecord;
+        try {
+            jacksonServiceRecord = (JacksonServiceRecord) serviceRecord;
+            JsonNode record = mapper.readTree(jacksonServiceRecord.toString()).get("record");
+
+            requestCount++;
+            totalCount++;
+            requestBytes += record.toString().getBytes().length;
+
+            records.add(record);
+            if (requestCount >= bulkActions || requestBytes >= bulkSize) {
+                client.push(record, task, retryHelper);
+                if (totalCount % 10000 == 0) {
+                    log.info("Inserted {} total records", totalCount);
+                }
+                requestBytes = 0;
+                requestCount = 0;
+            }
+        }
+        catch (ClassCastException ex) {
+            throw new RuntimeException(ex);
+        }
+        catch (IOException ex) {
+            throw Throwables.propagate(ex);
+        }
+    }
+
+    @Override
+    public TaskReport commitWithTaskReportUpdated(TaskReport taskReport)
+    {
+        if (!records.toString().isEmpty()) {
+            client.push(records, task, retryHelper);
+            log.info("Inserted {} total records", records.size());
+        }
+
+        this.retryHelper.close();
+        return Exec.newTaskReport().set("inserted", totalCount);
+    }
+}

--- a/src/test/java/org/embulk/output/elasticsearch/ElasticsearchTestUtils.java
+++ b/src/test/java/org/embulk/output/elasticsearch/ElasticsearchTestUtils.java
@@ -28,10 +28,8 @@ public class ElasticsearchTestUtils
     public static int ES_BULK_SIZE;
     public static int ES_CONCURRENT_REQUESTS;
     public static String PATH_PREFIX;
-
-    public static String ES_TEST_INDEX = "index_for_unittest";
-    public static String ES_TEST_INDEX2 = "index_for_unittest2";
-    public static String ES_TEST_ALIAS = "alias_for_unittest";
+    public static String ES_INDEX2;
+    public static String ES_ALIAS;
 
     /*
      * This test case requires environment variables
@@ -45,6 +43,8 @@ public class ElasticsearchTestUtils
         ES_PORT = System.getenv("ES_PORT") != null ? Integer.valueOf(System.getenv("ES_PORT")) : 9200;
 
         ES_INDEX = System.getenv("ES_INDEX");
+        ES_INDEX2 = ES_INDEX + "_02";
+        ES_ALIAS = ES_INDEX + "_alias";
         ES_INDEX_TYPE = System.getenv("ES_INDEX_TYPE");
         ES_ID = "id";
         ES_BULK_ACTIONS = System.getenv("ES_BULK_ACTIONS") != null ? Integer.valueOf(System.getenv("ES_BULK_ACTIONS")) : 1000;
@@ -66,17 +66,17 @@ public class ElasticsearchTestUtils
             deleteIndex.setAccessible(true);
 
             // Delete alias
-            if (client.isAliasExisting(ES_TEST_ALIAS, task, retryHelper)) {
-                deleteIndex.invoke(client, ES_TEST_ALIAS, task, retryHelper);
+            if (client.isAliasExisting(ES_ALIAS, task, retryHelper)) {
+                deleteIndex.invoke(client, ES_ALIAS, task, retryHelper);
             }
 
             // Delete index
-            if (client.isIndexExisting(ES_TEST_INDEX, task, retryHelper)) {
-                deleteIndex.invoke(client, ES_TEST_INDEX, task, retryHelper);
+            if (client.isIndexExisting(ES_INDEX, task, retryHelper)) {
+                deleteIndex.invoke(client, ES_INDEX, task, retryHelper);
             }
 
-            if (client.isIndexExisting(ES_TEST_INDEX2, task, retryHelper)) {
-                deleteIndex.invoke(client, ES_TEST_INDEX2, task, retryHelper);
+            if (client.isIndexExisting(ES_INDEX2, task, retryHelper)) {
+                deleteIndex.invoke(client, ES_INDEX2, task, retryHelper);
             }
         }
     }

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
@@ -16,10 +16,10 @@ import org.junit.Test;
 import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 
+import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_ALIAS;
 import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_INDEX;
+import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_INDEX2;
 import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_NODES;
-import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_TEST_ALIAS;
-import static org.embulk.output.elasticsearch.ElasticsearchTestUtils.ES_TEST_INDEX2;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -116,19 +116,19 @@ public class TestElasticsearchHttpClient
             String path = String.format("/%s/", ES_INDEX);
             sendRequest.invoke(client, path, HttpMethod.PUT, task, retryHelper);
 
-            path = String.format("/%s/", ES_TEST_INDEX2);
+            path = String.format("/%s/", ES_INDEX2);
             sendRequest.invoke(client, path, HttpMethod.PUT, task, retryHelper);
 
             // create alias
-            client.reassignAlias(ES_TEST_ALIAS, ES_INDEX, task, retryHelper);
+            client.reassignAlias(ES_ALIAS, ES_INDEX, task, retryHelper);
 
             // check alias
-            assertThat(client.isAliasExisting(ES_TEST_ALIAS, task, retryHelper), is(true));
-            assertThat(client.getIndexByAlias(ES_TEST_ALIAS, task, retryHelper).toString(), is("[" + ES_INDEX + "]"));
+            assertThat(client.isAliasExisting(ES_ALIAS, task, retryHelper), is(true));
+            assertThat(client.getIndexByAlias(ES_ALIAS, task, retryHelper).toString(), is("[" + ES_INDEX + "]"));
 
             // reassign index
-            client.reassignAlias(ES_TEST_ALIAS, ES_TEST_INDEX2, task, retryHelper);
-            assertThat(client.getIndexByAlias(ES_TEST_ALIAS, task, retryHelper).toString(), is("[" + ES_TEST_INDEX2 + "]"));
+            client.reassignAlias(ES_ALIAS, ES_INDEX2, task, retryHelper);
+            assertThat(client.getIndexByAlias(ES_ALIAS, task, retryHelper).toString(), is("[" + ES_INDEX2 + "]"));
         }
     }
 

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
@@ -169,7 +169,7 @@ public class TestElasticsearchOutputPlugin
 
         output.finish();
         output.commit();
-        Thread.sleep(1000); // Need to wait until index done
+        Thread.sleep(1500); // Need to wait until index done
 
         try (Jetty92RetryHelper retryHelper = utils.createRetryHelper()) {
             ElasticsearchHttpClient client = new ElasticsearchHttpClient();

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchOutputPlugin.java
@@ -146,55 +146,51 @@ public class TestElasticsearchOutputPlugin
         // no error happens
     }
 
-//    @Test
-//    public void testOutputByOpen() throws Exception
-//    {
-//        ConfigSource config = utils.config();
-//        Schema schema = config.getNested("parser").loadConfig(CsvParserPlugin.PluginTask.class).getSchemaConfig().toSchema();
-//        PluginTask task = config.loadConfig(PluginTask.class);
-//        plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
-//            @Override
-//            public List<TaskReport> run(TaskSource taskSource)
-//            {
-//                return Lists.newArrayList(Exec.newTaskReport());
-//            }
-//        });
-//        TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);
-//
-//        List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, 1L, 32864L, Timestamp.ofEpochSecond(1422386629), Timestamp.ofEpochSecond(1422316800),  true, 123.45, "embulk");
-//        assertThat(pages.size(), is(1));
-//        for (Page page : pages) {
-//            output.add(page);
-//        }
-//
-//        output.finish();
-//        output.commit();
-//
-//        try (Jetty92RetryHelper retryHelper = utils.createRetryHelper()) {
-//            ElasticsearchHttpClient client = new ElasticsearchHttpClient();
-//            Method sendRequest = ElasticsearchHttpClient.class.getDeclaredMethod("sendRequest", String.class, HttpMethod.class, PluginTask.class, Jetty92RetryHelper.class, String.class);
-//            sendRequest.setAccessible(true);
-//            String path = String.format("/%s/%s/_search", ES_INDEX, ES_INDEX_TYPE);
-//            String content = "{\"sort\" : \"id\"}";
-//            JsonNode response = (JsonNode) sendRequest.invoke(client, path, HttpMethod.POST, task, retryHelper, content);
-//            assertThat(response.get("hits").get("total").asInt(), is(4));
-//            System.out.println(response.get("hits").get("hits").get(0));
-//            if (response.size() > 0) {
-//                JsonNode record = response.get("hits").get("hits").get(0).get("_source");
-//                assertThat(record.get("id").asInt(), is(1));
-//                assertThat(record.get("account").asInt(), is(32864));
-//                //assertThat(record.get("time").asText(), is("2015-01-27T19:23:49.000Z")); // TODO
-//                assertThat(record.get("time").asInt(), is(1422386629));
-//                //assertThat(record.get("purchase").asText(), is("2015-01-27T00:00:00.000Z")); // TODO
-//                assertThat(record.get("purchase").asInt(), is(1422316800));
-//                //assertThat(record.get("flg").asBoolean(), is(true)); // TODO
-//                assertThat(record.get("flg"), null);
-//                //assertThat(record.get("score").asDouble(), is(123.45)); // TODO
-//                assertThat(record.get("score"), null);
-//                assertThat(record.get("comment").toString(), is("embulk"));
-//            }
-//        }
-//    }
+    @Test
+    public void testOutputByOpen() throws Exception
+    {
+        ConfigSource config = utils.config();
+        Schema schema = config.getNested("parser").loadConfig(CsvParserPlugin.PluginTask.class).getSchemaConfig().toSchema();
+        PluginTask task = config.loadConfig(PluginTask.class);
+        plugin.transaction(config, schema, 0, new OutputPlugin.Control() {
+            @Override
+            public List<TaskReport> run(TaskSource taskSource)
+            {
+                return Lists.newArrayList(Exec.newTaskReport());
+            }
+        });
+        TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);
+
+        List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), schema, 1L, 32864L, Timestamp.ofEpochSecond(1422386629), Timestamp.ofEpochSecond(1422316800),  true, 123.45, "embulk");
+        assertThat(pages.size(), is(1));
+        for (Page page : pages) {
+            output.add(page);
+        }
+
+        output.finish();
+        output.commit();
+        Thread.sleep(1000); // Need to wait until index done
+
+        try (Jetty92RetryHelper retryHelper = utils.createRetryHelper()) {
+            ElasticsearchHttpClient client = new ElasticsearchHttpClient();
+            Method sendRequest = ElasticsearchHttpClient.class.getDeclaredMethod("sendRequest", String.class, HttpMethod.class, PluginTask.class, Jetty92RetryHelper.class, String.class);
+            sendRequest.setAccessible(true);
+            String path = String.format("/%s/%s/_search", ES_INDEX, ES_INDEX_TYPE);
+            String sort = "{\"sort\" : \"id\"}";
+            JsonNode response = (JsonNode) sendRequest.invoke(client, path, HttpMethod.POST, task, retryHelper, sort);
+            assertThat(response.get("hits").get("total").asInt(), is(1));
+            if (response.size() > 0) {
+                JsonNode record = response.get("hits").get("hits").get(0).get("_source");
+                assertThat(record.get("id").asInt(), is(1));
+                assertThat(record.get("account").asInt(), is(32864));
+                assertThat(record.get("time").asText(), is("2015-01-27T19:23:49.000+0000"));
+                assertThat(record.get("purchase").asText(), is("2015-01-27T00:00:00.000+0000"));
+                assertThat(record.get("flg").asBoolean(), is(true));
+                assertThat(record.get("score").asDouble(), is(123.45));
+                assertThat(record.get("comment").asText(), is("embulk"));
+            }
+        }
+    }
 
     @Test
     public void testOpenAbort()


### PR DESCRIPTION
Current implementation may cause OOM as @dmikurube commented at https://github.com/muga/embulk-output-elasticsearch/pull/32#discussion_r105589282.

I implemented original RecordBuffer to avoid this problem.
Also enabled unit test for export logic.