### PR TITLE
Improve exception handling

### DIFF
--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
@@ -310,7 +310,7 @@ public class ElasticsearchHttpClient
         return sendRequest(path, method, task, retryHelper, "");
     }
 
-    private JsonNode sendRequest(String path, final HttpMethod method, PluginTask task, Jetty92RetryHelper retryHelper, final String content)
+    private JsonNode sendRequest(String path, final HttpMethod method, final PluginTask task, Jetty92RetryHelper retryHelper, final String content)
     {
         final String uri = createRequestUri(task, path);
         final String authorizationHeader = getAuthorizationHeader(task);
@@ -338,7 +338,7 @@ public class ElasticsearchHttpClient
                     @Override
                     public boolean isExceptionToRetry(Exception exception)
                     {
-                        return true;
+                        return task.getId().isPresent();
                     }
 
                     @Override
@@ -347,7 +347,8 @@ public class ElasticsearchHttpClient
                         int status = response.getStatus();
                         if (status == 404) {
                             throw new ResourceNotFoundException("Requested resource was not found");
-                        } else if (status == 429) {
+                        }
+                        else if (status == 429) {
                             return true;  // Retry if 429.
                         }
                         return status / 100 != 4;  // Retry unless 4xx except for 429.

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
@@ -337,6 +337,12 @@ public class ElasticsearchHttpClient
                         }
 
                         @Override
+                        public boolean isExceptionToRetry(Exception exception)
+                        {
+                            return true;
+                        }
+
+                        @Override
                         public boolean isResponseStatusToRetry(org.eclipse.jetty.client.api.Response response)
                         {
                             int status = response.getStatus();


### PR DESCRIPTION
This plugin sometimes throws TimeoutException while pushing data to Elasticsaerch node.
I checked code again and found current implementation doesn't retry when Exception happens while pushing data.

### Changes

* Override `Jetty92SingleRequester.isExceptionToRetry(Exception exception)` and return true to force to retry
3570790bded024220e057013d3302362e79e4fc2
* Change 404 detect logic(minor) 1e3f08939743db0d996e6ab982466787049aa50d

### Stacktrace
```
java.lang.RuntimeException: java.util.concurrent.TimeoutException
org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: java.util.concurrent.TimeoutException
	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:373)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:591)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:389)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:385)
	at org.embulk.spi.Exec.doWith(Exec.java:25)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:385)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
	... ...
Caused by: java.lang.RuntimeException: java.util.concurrent.TimeoutException
	at com.google.common.base.Throwables.propagate(Throwables.java:160)
	at org.embulk.util.retryhelper.jetty92.Jetty92RetryHelper.requestWithRetry(Jetty92RetryHelper.java:164)
	at org.embulk.output.elasticsearch.ElasticsearchHttpClient.sendRequest(ElasticsearchHttpClient.java:319)
	at org.embulk.output.elasticsearch.ElasticsearchHttpClient.push(ElasticsearchHttpClient.java:81)
	at org.embulk.output.elasticsearch.ElasticsearchRecordBuffer.bufferRecord(ElasticsearchRecordBuffer.java:71)
	at org.embulk.base.restclient.RestClientPageOutput.add(RestClientPageOutput.java:44)
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:249)
	at org.embulk.spi.PageBuilder.flush(PageBuilder.java:255)
	at org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:232)
	at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:280)
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:156)
	at org.embulk.spi.util.Executors.process(Executors.java:67)
	at org.embulk.spi.util.Executors.process(Executors.java:42)
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184)
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.util.concurrent.TimeoutException
	at org.eclipse.jetty.client.util.InputStreamResponseListener.get(InputStreamResponseListener.java:226)
	at org.embulk.util.retryhelper.jetty92.StringJetty92ResponseEntityReader.getResponse(StringJetty92ResponseEntityReader.java:31)
	at org.embulk.util.retryhelper.jetty92.Jetty92RetryHelper$1.call(Jetty92RetryHelper.java:107)
	at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:100)
	at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:77)
	at org.embulk.util.retryhelper.jetty92.Jetty92RetryHelper.requestWithRetry(Jetty92RetryHelper.java:95)
	... 17 more
```