### PR TITLE
Create RetryHelper instance only at sendRequest() method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.16"
     provided  "org.embulk:embulk-core:0.8.16"
-    compile  "org.embulk.base.restclient:embulk-base-restclient:0.5.2"
-    compile  "org.embulk.base.restclient:embulk-util-retryhelper-jetty92:0.5.2"
+    compile  "org.embulk.base.restclient:embulk-base-restclient:0.5.3"
+    compile  "org.embulk.base.restclient:embulk-util-retryhelper-jetty92:0.5.3"
 
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.16:tests"

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchRecordBuffer.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchRecordBuffer.java
@@ -86,6 +86,16 @@ public class ElasticsearchRecordBuffer
     }
 
     @Override
+    public void finish()
+    {
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
     public TaskReport commitWithTaskReportUpdated(TaskReport taskReport)
     {
         try {

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchRecordBuffer.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchRecordBuffer.java
@@ -12,7 +12,6 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.config.TaskReport;
 import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.PluginTask;
 import org.embulk.spi.Exec;
-import org.embulk.util.retryhelper.jetty92.Jetty92RetryHelper;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -28,7 +27,6 @@ public class ElasticsearchRecordBuffer
     private final long bulkActions;
     private final long bulkSize;
     private final ElasticsearchHttpClient client;
-    private final Jetty92RetryHelper retryHelper;
     private final ObjectMapper mapper;
     private final Logger log;
     private long totalCount;
@@ -36,14 +34,13 @@ public class ElasticsearchRecordBuffer
     private long requestBytes;
     private ArrayNode records;
 
-    public ElasticsearchRecordBuffer(String attributeName, PluginTask task, Jetty92RetryHelper retryHelper)
+    public ElasticsearchRecordBuffer(String attributeName, PluginTask task)
     {
         this.attributeName = attributeName;
         this.task = task;
         this.bulkActions = task.getBulkActions();
         this.bulkSize = task.getBulkSize();
         this.client = new ElasticsearchHttpClient();
-        this.retryHelper = retryHelper;
         this.mapper = new ObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false);
@@ -68,7 +65,7 @@ public class ElasticsearchRecordBuffer
 
             records.add(record);
             if (requestCount >= bulkActions || requestBytes >= bulkSize) {
-                client.push(records, task, retryHelper);
+                client.push(records, task);
                 if (totalCount % 10000 == 0) {
                     log.info("Inserted {} records", totalCount);
                 }
@@ -98,15 +95,10 @@ public class ElasticsearchRecordBuffer
     @Override
     public TaskReport commitWithTaskReportUpdated(TaskReport taskReport)
     {
-        try {
-            if (records.size() > 0) {
-                client.push(records, task, retryHelper);
-                log.info("Inserted {} records", records.size());
-            }
-            return Exec.newTaskReport().set("inserted", totalCount);
+        if (records.size() > 0) {
+            client.push(records, task);
+            log.info("Inserted {} records", records.size());
         }
-        finally {
-            this.retryHelper.close();
-        }
+        return Exec.newTaskReport().set("inserted", totalCount);
     }
 }

--- a/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
+++ b/src/test/java/org/embulk/output/elasticsearch/TestElasticsearchHttpClient.java
@@ -7,7 +7,6 @@ import org.embulk.config.ConfigSource;
 import org.embulk.output.elasticsearch.ElasticsearchOutputPluginDelegate.PluginTask;
 import org.embulk.spi.Exec;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.util.retryhelper.jetty92.Jetty92RetryHelper;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -103,53 +102,47 @@ public class TestElasticsearchHttpClient
     public void testCreateAlias() throws Exception
     {
         ElasticsearchHttpClient client = new ElasticsearchHttpClient();
-        try (Jetty92RetryHelper retryHelper = utils.createRetryHelper()) {
-            PluginTask task = utils.config().loadConfig(PluginTask.class);
-            // delete index
-            Method method = ElasticsearchHttpClient.class.getDeclaredMethod("deleteIndex", String.class, PluginTask.class, Jetty92RetryHelper.class);
-            method.setAccessible(true);
-            method.invoke(client, "newindex", task, retryHelper);
+        PluginTask task = utils.config().loadConfig(PluginTask.class);
+        // delete index
+        Method method = ElasticsearchHttpClient.class.getDeclaredMethod("deleteIndex", String.class, PluginTask.class);
+        method.setAccessible(true);
+        method.invoke(client, "newindex", task);
 
-            // create index
-            Method sendRequest = ElasticsearchHttpClient.class.getDeclaredMethod("sendRequest", String.class, HttpMethod.class, PluginTask.class, Jetty92RetryHelper.class);
-            sendRequest.setAccessible(true);
-            String path = String.format("/%s/", ES_INDEX);
-            sendRequest.invoke(client, path, HttpMethod.PUT, task, retryHelper);
+        // create index
+        Method sendRequest = ElasticsearchHttpClient.class.getDeclaredMethod("sendRequest", String.class, HttpMethod.class, PluginTask.class);
+        sendRequest.setAccessible(true);
+        String path = String.format("/%s/", ES_INDEX);
+        sendRequest.invoke(client, path, HttpMethod.PUT, task);
 
-            path = String.format("/%s/", ES_INDEX2);
-            sendRequest.invoke(client, path, HttpMethod.PUT, task, retryHelper);
+        path = String.format("/%s/", ES_INDEX2);
+        sendRequest.invoke(client, path, HttpMethod.PUT, task);
 
-            // create alias
-            client.reassignAlias(ES_ALIAS, ES_INDEX, task, retryHelper);
+        // create alias
+        client.reassignAlias(ES_ALIAS, ES_INDEX, task);
 
-            // check alias
-            assertThat(client.isAliasExisting(ES_ALIAS, task, retryHelper), is(true));
-            assertThat(client.getIndexByAlias(ES_ALIAS, task, retryHelper).toString(), is("[" + ES_INDEX + "]"));
+        // check alias
+        assertThat(client.isAliasExisting(ES_ALIAS, task), is(true));
+        assertThat(client.getIndexByAlias(ES_ALIAS, task).toString(), is("[" + ES_INDEX + "]"));
 
-            // reassign index
-            client.reassignAlias(ES_ALIAS, ES_INDEX2, task, retryHelper);
-            assertThat(client.getIndexByAlias(ES_ALIAS, task, retryHelper).toString(), is("[" + ES_INDEX2 + "]"));
-        }
+        // reassign index
+        client.reassignAlias(ES_ALIAS, ES_INDEX2, task);
+        assertThat(client.getIndexByAlias(ES_ALIAS, task).toString(), is("[" + ES_INDEX2 + "]"));
     }
 
     @Test
     public void testIsIndexExistingWithNonExistsIndex()
     {
         ElasticsearchHttpClient client = new ElasticsearchHttpClient();
-        try (Jetty92RetryHelper retryHelper = utils.createRetryHelper()) {
-            PluginTask task = utils.config().loadConfig(PluginTask.class);
-            assertThat(client.isIndexExisting("non-existing-index", task, retryHelper), is(false));
-        }
+        PluginTask task = utils.config().loadConfig(PluginTask.class);
+        assertThat(client.isIndexExisting("non-existing-index", task), is(false));
     }
 
     @Test
     public void testIsAliasExistingWithNonExistsAlias()
     {
         ElasticsearchHttpClient client = new ElasticsearchHttpClient();
-        try (Jetty92RetryHelper retryHelper = utils.createRetryHelper()) {
-            PluginTask task = utils.config().loadConfig(PluginTask.class);
-            assertThat(client.isAliasExisting("non-existing-alias", task, retryHelper), is(false));
-        }
+        PluginTask task = utils.config().loadConfig(PluginTask.class);
+        assertThat(client.isAliasExisting("non-existing-alias", task), is(false));
     }
 
     @Test


### PR DESCRIPTION
This plugin sometimes hung up(processing stopped but doesn't finish with error).

To avoid this problem I changed implementation to create RetryHelper only at `ElasticsearchHttpClient.sendRequest()` and close RetryHelper every time.