### PR TITLE
Show warning logs instead of throwing ConfigException for AWS ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Elasticsearch output plugin for Embulk
 
-**Notice** This plugin doesn't support [Amazon(AWS) Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/).
-This plugin uses HTTP/REST Client and haven't be implemented AWS authentication.
+**Notice** This plugin doesn't positively support [Amazon(AWS) Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/).
+Actually, AWS Elasticsearch Service supported AWS VPC at Oct 2017 and user is able to access to Es from EC2 instances in VPC subnet without any authentication.
+You can use this plugin for AWS ES at your own risk.
+
 - *[Amazon Elasticsearch Service Limits](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html)*
 
 ## Overview

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -193,7 +193,7 @@ public class ElasticsearchOutputPluginDelegate
         if (task.getNodes().size() > 0) {
             for (NodeAddressTask node : task.getNodes()) {
                 if (node.getHost().endsWith("es.amazonaws.com")) {
-                    log.warn("This plugin does't support AWS Elasticsearch Service.");
+                    log.warn("This plugin does't support AWS Elasticsearch Service. See README https://github.com/embulk/embulk-output-elasticsearch/blob/master/README.md");
                 }
                 if (node.getPort() == 9300) {
                     log.warn("Port:9300 is usually used by TransportClient. HTTP/Rest Client uses 9200.");

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -193,7 +193,7 @@ public class ElasticsearchOutputPluginDelegate
         if (task.getNodes().size() > 0) {
             for (NodeAddressTask node : task.getNodes()) {
                 if (node.getHost().endsWith("es.amazonaws.com")) {
-                    throw new ConfigException("This plugin does't support AWS Elasticsearch Service.");
+                    log.warn("This plugin does't support AWS Elasticsearch Service.");
                 }
                 if (node.getPort() == 9300) {
                     log.warn("Port:9300 is usually used by TransportClient. HTTP/Rest Client uses 9200.");


### PR DESCRIPTION
Fix for #24 

We're now throwing ConfigException when Es host URI ends with `es.amazonaws.com`.

AWS Elasticsearch Service supported AWS VPC at Oct 2017 and user is able to access to Es without any Authentication.
[Amazon Elasticsearch Service now supports VPC | AWS News Blog](https://aws.amazon.com/jp/blogs/aws/amazon-elasticsearch-service-now-supports-vpc/)

I changed implementation to show warn logs instead of throwing ConfigException.
And confirmed this change works fine at EC2 instance located at VPC network/subnet.