### PR TITLE
Only build for Java8 and fix Travis CI Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-dist: precise
 language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 
 env:
   global:
@@ -25,7 +22,3 @@ before_script:
 script:
   - ./gradlew gem
   - ./gradlew --info check jacocoTestReport
-addons:
-  hosts:
-    - example.com
-  hostname: example.com

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ group = "org.embulk.output.elasticsearch"
 version = "0.4.5"
 
 compileJava.options.encoding = 'UTF-8' // source encoding
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     compile  "org.embulk:embulk-core:0.8.36"


### PR DESCRIPTION
Recently I got build failure only with Java7 at Travis CI. Build succeeded with Java8.
https://travis-ci.org/embulk/embulk-output-elasticsearch/builds/410669280

Travis stopped to support Java7 and it's time to remove it from .travis.yml

Additionally, We're going to support Java8 with Embulk and its plugins. I updated build.gradle.

ref. https://github.com/embulk/embulk-input-gcs/pull/35