### PR TITLE
Add connect_timeout_millis option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This plugin uses HTTP/REST Client and haven't be implemented AWS authentication.
 - **initial_retry_interval_millis** Initial interval between retries in milliseconds (int, optional, default is 1000)
 - **maximum_retry_interval_millis** Maximum interval between retries in milliseconds (int, optional, default is 120000)
 - **timeout_millis** timeout in milliseconds for each HTTP request(int, optional, default is 60000)
+- **socket_timeout_millis** socket timeout in milliseconds for HTTP client(int, optional, default is 60000)
 - **max_snapshot_waiting_secs** maximam waiting time in second when snapshot is just creating before delete index. works when `mode: replace` (int, optional, default is 1800)
 ### Modes
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This plugin uses HTTP/REST Client and haven't be implemented AWS authentication.
 - **initial_retry_interval_millis** Initial interval between retries in milliseconds (int, optional, default is 1000)
 - **maximum_retry_interval_millis** Maximum interval between retries in milliseconds (int, optional, default is 120000)
 - **timeout_millis** timeout in milliseconds for each HTTP request(int, optional, default is 60000)
-- **socket_timeout_millis** socket timeout in milliseconds for HTTP client(int, optional, default is 60000)
+- **connect_timeout_millis** connection timeout in milliseconds for HTTP client(int, optional, default is 60000)
 - **max_snapshot_waiting_secs** maximam waiting time in second when snapshot is just creating before delete index. works when `mode: replace` (int, optional, default is 1800)
 ### Modes
 

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
@@ -393,7 +393,7 @@ public class ElasticsearchHttpClient
         }
     }
 
-    private Jetty92RetryHelper createRetryHelper(PluginTask task)
+    private Jetty92RetryHelper createRetryHelper(final PluginTask task)
     {
         return new Jetty92RetryHelper(
                 task.getMaximumRetries(),
@@ -404,6 +404,7 @@ public class ElasticsearchHttpClient
                     public org.eclipse.jetty.client.HttpClient createAndStart()
                     {
                         org.eclipse.jetty.client.HttpClient client = new org.eclipse.jetty.client.HttpClient(new SslContextFactory());
+                        client.setConnectTimeout(task.getSocketTimeoutMills());
                         try {
                             client.start();
                             return client;

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchHttpClient.java
@@ -404,7 +404,7 @@ public class ElasticsearchHttpClient
                     public org.eclipse.jetty.client.HttpClient createAndStart()
                     {
                         org.eclipse.jetty.client.HttpClient client = new org.eclipse.jetty.client.HttpClient(new SslContextFactory());
-                        client.setConnectTimeout(task.getSocketTimeoutMills());
+                        client.setConnectTimeout(task.getConnectTimeoutMills());
                         try {
                             client.start();
                             return client;

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -122,9 +122,9 @@ public class ElasticsearchOutputPluginDelegate
         @ConfigDefault("60000")
         int getTimeoutMills();
 
-        @Config("socket_timeout_millis")
+        @Config("connect_timeout_millis")
         @ConfigDefault("60000")
-        int getSocketTimeoutMills();
+        int getConnectTimeoutMills();
 
         @Config("max_snapshot_waiting_secs")
         @ConfigDefault("1800")

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -122,6 +122,10 @@ public class ElasticsearchOutputPluginDelegate
         @ConfigDefault("60000")
         int getTimeoutMills();
 
+        @Config("socket_timeout_millis")
+        @ConfigDefault("60000")
+        int getSocketTimeoutMills();
+
         @Config("max_snapshot_waiting_secs")
         @ConfigDefault("1800")
         int getMaxSnapshotWaitingSecs();


### PR DESCRIPTION
Related with #51 
Existing `timeout_millis` should be used for connection timeout for each HTTP requests.
But original problem reported #51 need socket_timeout settings.
I added new option `socket_timeout_millis`
http://www.eclipse.org/jetty/javadoc/9.2.22.v20170606/org/eclipse/jetty/client/HttpClient.html#setConnectTimeout(long)