### PR TITLE
Remove joda time usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 services:
   - docker

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -225,22 +225,10 @@ public class ElasticsearchOutputPluginDelegate
         }
     }
 
-    private static interface FormatterIntlTask extends Task, TimestampFormatter.Task {}
-    private static interface FormatterIntlColumnOption extends Task, TimestampFormatter.TimestampColumnOption {}
-
     @Override  // Overridden from |ServiceRequestMapperBuildable|
     public JacksonServiceRequestMapper buildServiceRequestMapper(PluginTask task)
     {
-        // TODO: Switch to a newer TimestampFormatter constructor after a reasonable interval.
-        // Traditional constructor is used here for compatibility.
-        final ConfigSource configSource = Exec.newConfigSource();
-        configSource.set("format", "%Y-%m-%dT%H:%M:%S.%3N%z");
-        configSource.set("timezone", task.getTimeZone());
-        TimestampFormatter formatter = TimestampFormatter.of(
-            Exec.newConfigSource().loadConfig(FormatterIntlTask.class),
-            com.google.common.base.Optional.fromNullable(configSource.loadConfig(FormatterIntlColumnOption.class))
-        );
-
+        TimestampFormatter formatter = TimestampFormatter.of("%Y-%m-%dT%H:%M:%S.%3N%z", task.getTimeZone());
         return JacksonServiceRequestMapper.builder()
                 .add(new JacksonAllInObjectScope(formatter, task.getFillNullForEmptyColumn()), new JacksonTopLevelValueLocator("record"))
                 .build();

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -18,7 +18,6 @@ import org.embulk.config.TaskReport;
 import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
 import org.embulk.spi.time.TimestampFormatter;
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -236,7 +235,7 @@ public class ElasticsearchOutputPluginDelegate
         // Traditional constructor is used here for compatibility.
         final ConfigSource configSource = Exec.newConfigSource();
         configSource.set("format", "%Y-%m-%dT%H:%M:%S.%3N%z");
-        configSource.set("timezone", DateTimeZone.forID(task.getTimeZone()));
+        configSource.set("timezone", task.getTimeZone());
         TimestampFormatter formatter = TimestampFormatter.of(
             Exec.newConfigSource().loadConfig(FormatterIntlTask.class),
             com.google.common.base.Optional.fromNullable(configSource.loadConfig(FormatterIntlColumnOption.class))

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -12,7 +12,6 @@ import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
-import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Exec;


### PR DESCRIPTION
Remove Joda-Time usage
Justification:
Joda-Time would be deprecated and removed from Embulk.

And actual definition for `FormatterIntlColumnOption` is using `String` type:

https://github.com/embulk/embulk/blob/4b8250d88792cd4e9024903e133b76758ef6a02e/embulk-core/src/main/java/org/embulk/spi/time/TimestampParser.java#L185-L188 
