### PR TITLE
Nominate developers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,20 +126,12 @@ publishing {
                         email = "frsyuki@gmail.com"
                     }
                     developer {
-                        name = "hirakiuc"
-                        email = "hirakiuc@gmail.com"
-                    }
-                    developer {
                         name = "Toyama Hiroshi"
                         email = "toyama0919@gmail.com"
                     }
                     developer {
                         name = "Satoshi Akama"
                         email = "satoshiakama@gmail.com"
-                    }
-                    developer {
-                        name = "Kevin M Fitzgerald"
-                        email = "kevin@kevinfitzgerald.net"
                     }
                     developer {
                         name = "Serhii Himadieiev"

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,38 @@ publishing {
                 }
 
                 developers {
+                    developer {
+                        name = "Muga Nishizawa"
+                        email = "muga.nishizawa@gmail.com"
+                    }
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "hirakiuc"
+                        email = "hirakiuc@gmail.com"
+                    }
+                    developer {
+                        name = "Toyama Hiroshi"
+                        email = "toyama0919@gmail.com"
+                    }
+                    developer {
+                        name = "Satoshi Akama"
+                        email = "satoshiakama@gmail.com"
+                    }
+                    developer {
+                        name = "Kevin M Fitzgerald"
+                        email = "kevin@kevinfitzgerald.net"
+                    }
+                    developer {
+                        name = "Serhii Himadieiev"
+                        email = "gimadeevsv@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
                 }
 
                 scm {


### PR DESCRIPTION
We're going to release JARs of `embulk-output-elasticsearch` to Maven Central from 0.5.0 (#66).

Maven Central needs the `<developers>` section available in `pom.xml`. In this chance, trying to nominate developers who have contributed a important portion in `embulk-output-elasticsearch` from the Git log.